### PR TITLE
Fix desktop set drag placeholder issue

### DIFF
--- a/src/js/components/SetsManager.js
+++ b/src/js/components/SetsManager.js
@@ -150,6 +150,7 @@ export class SetsManager {
             this.draggedElement.style.width = '';
             this.draggedElement.style.top = '';
             this.draggedElement.style.left = '';
+            this.draggedElement.style.display = '';
         }
         if (this.placeholder && this.placeholder.parentNode) {
             this.placeholder.parentNode.removeChild(this.placeholder);
@@ -180,18 +181,20 @@ export class SetsManager {
             
             // Вставляем плейсхолдер на место перетаскиваемого элемента
             this.draggedElement.parentNode.insertBefore(this.placeholder, this.draggedElement);
-            
+
             e.dataTransfer.setData('text/plain', setName);
             setElement.classList.add('dragging');
-            
-            // Устанавливаем прозрачность для оригинального элемента
+
+            // Прячем исходный элемент, чтобы освободить место в списке
             setElement.style.opacity = '0.5';
+            setElement.style.display = 'none';
         });
 
         setElement.addEventListener('dragend', () => {
             console.log('Dragend:', setName);
             if (this.draggedElement) {
                 this.draggedElement.style.opacity = '';
+                this.draggedElement.style.display = '';
             }
             this.resetDragState();
         });


### PR DESCRIPTION
## Summary
- hide item during drag start and restore on drag end
- reset item visibility when clearing drag state

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check src/js/components/SetsManager.js`


------
https://chatgpt.com/codex/tasks/task_e_6852a4ebf6e8832eac0a0e121f06807e